### PR TITLE
Add Lua runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 | PHP 7.1 | ARN: `arn:aws:lambda:<region>:887080169480:layer:php71:3`<br>Link:[`stackery/php-lambda-layer`](https://github.com/stackery/php-lambda-layer) | `provided` |
 | Brainfuck | ARN: `arn:aws:lambda:<region>:444134189787:layer:brainfuck:1`<br>Built for fun, will not process events! | `provided` |
 | LOLCODE | ARN: `arn:aws:lambda:<region>:444134189787:layer:lolcode:1`<br>Built for fun, will not process events! | `provided` |
-
+| Lua (alpha) | Link: [burck1/aws-lambda-lua-runtime](https://github.com/burck1/aws-lambda-lua-runtime) | `provided` |
 
 
 ### Utilities


### PR DESCRIPTION
Note: This Lua runtime is something I've hacked together in a weekend. Right now it's not really a runtime, but rather it just uses the Bash runtime to download the Lua binary and run an `index.lua` script. If people are looking for a Lua based runtime for AWS Lambda, the plan would be to create a C/C++ binary for a custom Lua runtime that uses the Lua C api to invoke the users Lua function based on the handler string.