### PR TITLE
Add serverless-latest-layer-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,10 @@
 |------|------------|---------------------|
 | [Protego](https://protego.io/) | Link: [Protego Layers and Runtimes](https://www.protego.io/layers-and-runtimes-protego/) | `python2.7, python3.6, python3.7, nodejs6.10, nodejs8.10, java8, dotnetcore2.0, dotnetcore2.1` |
 | [PureSec](https://www.puresec.io/) | Link: [PureSec Lambda Protection Layer](https://www.puresec.io/blog/aws-lambda-security-with-zero-overhead-by-puresec) | `nodejs8.10, nodejs6.10, python2.7, python3.6, python3.7, java8, dotnetcore2.x`|
+
+
+## Utilities
+
+| Name | Link | 
+| ---- | ---- |
+| [serverless-latest-layer-version](https://github.com/mooyoul/serverless-latest-layer-version) | [Github](https://github.com/mooyoul/serverless-latest-layer-version), [NPM](https://www.npmjs.com/package/serverless-latest-layer-version) |


### PR DESCRIPTION
I made `serverless-latest-layer-version` to rescue missing `$LATEST` version tag 😄 
