### PR TITLE
Add Ballerina AWS Lambda Layer Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | C++ (official) | Link: [awslabs/aws-lambda-cpp](https://github.com/awslabs/aws-lambda-cpp) | `provided` |
 | Rust (official) | Link: [awslabs/aws-lambda-rust-runtime](https://github.com/awslabs/aws-lambda-rust-runtime) | `provided` |
 | Bash | ARN: `arn:aws:lambda:<region>:744348701589:layer:bash:4`<br>Link: [`gkrizek/bash-lambda-layer`](https://github.com/gkrizek/bash-lambda-layer) | `provided` |
+| Ballerina | Link: [ballerina.io/deployment/aws-lambda](https://ballerina.io/deployment/aws-lambda/) | `provided` |
 | [Crystal](https://crystal-lang.org/) | Link: [lambci/crambda](https://github.com/lambci/crambda) | `provided` |
 | [Nim](https://nim-lang.org/) | Link: [lambci/awslambda.nim](https://github.com/lambci/awslambda.nim) | `provided` |
 | Node.js v8 - N\|Solid | ARN: `arn:aws:lambda:<region>:800406105498:layer:nsolid-node-8:3`<br>Link: [accounts.nodesource.com/downloads/nsolid-lambda](https://accounts.nodesource.com/downloads/nsolid-lambda) | `provided` |


### PR DESCRIPTION
This adds the [Ballerina](https://ballerina.io) language runtime AWS lambda layer. 

The usage of this has been explained in https://ballerina.io/learn/by-guide/ballerina-awslambda-deployment/ and https://ballerina.io/learn/by-example/awslambda-deployment.html. 