### PR TITLE
Adding Java 11 Runtime to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | PHP 7.1 | ARN: `arn:aws:lambda:<region>:887080169480:layer:php71:3`<br>Link:[`stackery/php-lambda-layer`](https://github.com/stackery/php-lambda-layer) | `provided` |
 | Brainfuck | ARN: `arn:aws:lambda:<region>:444134189787:layer:brainfuck:1`<br>Built for fun, will not process events! | `provided` |
 | LOLCODE | ARN: `arn:aws:lambda:<region>:444134189787:layer:lolcode:1`<br>Built for fun, will not process events! | `provided` |
+| Java 11 | Link: [andthearchitect/aws-lambda-java-runtime](https://github.com/andthearchitect/aws-lambda-java-runtime) | `provided` |
 
 
 ### Utilities


### PR DESCRIPTION
I've created a Java Custom Runtime which I've love to get on this list. It's currently using Java 11 but could easily be configured to use any version.