### PR TITLE
Add link to blog post about sharing Lambda Layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 * [with AWS CLI](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) ([tutorial](https://github.com/nsriram/aws-lambda-layer-example)),
 * [with Stackery](https://www.stackery.io/blog/lambda-layers/)
 
+## How to share Lambda Layers publicly?
+
+* [Tutorial with CLI examples](https://medium.com/@zaccharles/f1413b974f44)
+
 ## Layers
 
 ### Runtimes


### PR DESCRIPTION
I added a link to my blog post about sharing Lambda Layers.

This information was helpful to me when I was trying to make a layer public.
The AWS documentation exists but is a bit all over the place, so I simplified it and provided easier examples.

Not sure if the actual README.md edit (wording, formatting, etc.) is okay?