### PR TITLE
Add postgres libpq

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
 | kubectl for Amazon EKS | Link: [`pahud/lambda-layer-kubectl`](https://github.com/pahud/lambda-layer-kubectl) | all |
 | MySQL PHP 7.1 | Link: [`aiir/php71-mysql-aws-lambda-layer`](https://github.com/aiir/php71-mysql-aws-lambda-layer) | [`stackery/php-lambda-layer`](https://github.com/stackery/php-lambda-layer) |
 | Pandoc | ARN: `arn:aws:lambda:us-east-1:145266761615:layer:pandoc:1`<br>Link: [`serverlesspub/pandoc-aws-lambda-binary`](https://github.com/serverlesspub/pandoc-aws-lambda-binary) | all |
+| PostgreSQL libpq | https://github.com/DrLuke/postgres-libpq-aws-lambda-layer | all |
 | Puppeteer | ARN: `arn:aws:lambda:us-east-1:085108115628:layer:chrome:6`<br>Link: [`RafalWilinski/serverless-puppeteer-layers`](https://github.com/RafalWilinski/serverless-puppeteer-layers) | all |
 | psycopg2  | Link: [`jetbridge/psycopg2-lambda-layer`](https://github.com/jetbridge/psycopg2-lambda-layer)  | `python3.6` `python3.7` |
 | Python Toolkit | Link: [`keithrozario/Klayers`](https://github.com/keithrozario/Klayers)<br>Python packages incl. requests, aiohttp, pyOpenSSL etc.| `python3.7`|


### PR DESCRIPTION
Adds a layer for postgresql, which is required for psycopg2 in python. It contains the minimum amount of necessary libs to allow psycopg2 to work when installed from pip.

ARNs might be added later, I currently don't own a private AWS account to do host this from.