### PR TITLE
Add ClamAV layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 | Name | ARN / Link | Compatible Runtimes |
 |------|------------|---------------------|
 | AWS CLI | Link: [`pahud/lambda-layer-awscli`](https://github.com/pahud/lambda-layer-awscli) | all |
+| ClamAV | Link: [`kindlyops/lambda-clamav-layer`](https://github.com/kindlyops/lambda-clamav-layer) | all |
 | FFmpeg/FFprobe | ARN: `arn:aws:lambda:us-east-1:145266761615:layer:ffmpeg:4`<br>Link: [`serverlesspub/ffmpeg-aws-lambda-layer`](https://github.com/serverlesspub/ffmpeg-aws-lambda-layer) | all |
 | GeoIP | Link: [`dschep/geoip-lambda-layer`](https://github.com/dschep/geoip-lambda-layer) | all |
 | Git + SSH | ARN: `arn:aws:lambda:<region>:553035198032:layer:git:<version>`<br>Link: [`lambci/git-lambda-layer`](https://github.com/lambci/git-lambda-layer) | all |


### PR DESCRIPTION
Hi!

This adds a link to a ClamAV layer, which makes the clamav binaries available for use inside lambda functions that wish to access antivirus capabilities.
