### PR TITLE
Updated ARN of PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@
 | Git + SSH | ARN: `arn:aws:lambda:<region>:553035198032:layer:git:<version>`<br>Link: [`lambci/git-lambda-layer`](https://github.com/lambci/git-lambda-layer) | all |
 | GraphicsMagick | ARN: `arn:aws:lambda:<region>:175033217214:layer:graphicsmagick:<version>`<br>Link: [`rpidanny/gm-lambda-layer`](https://github.com/rpidanny/gm-lambda-layer) | all |
 | headless chromium with CJK fonts | Link: [`pahud/lambda-layer-headless-chromium`](https://github.com/pahud/lambda-layer-headless-chromium) | all |
-| Headless PhantomJS | ARN: `arn:aws:lambda:us-east-1:699054759624:layer:phantom-js:4`<br> Link: [`shivtej1505/phantom-js-lambda-layer`](https://github.com/shivtej1505/phantom-js-lambda-layer) | all |
+| Headless PhantomJS | ARN: `arn:aws:lambda:us-west-2:699054759624:layer:phantom-js:1`<br> Link: [`shivtej1505/phantom-js-lambda-layer`](https://github.com/shivtej1505/phantom-js-lambda-layer) | all |
 | Hugo | Link: [`jason-dour/hugo-aws-lambda-layer`](https://github.com/jason-dour/hugo-aws-lambda-layer) | all |
 | kubectl for Amazon EKS | Link: [`aws-samples/aws-lambda-layer-kubectl`](https://github.com/aws-samples/aws-lambda-layer-kubectl) | all |
 | LibreOffice | ARN: `arn:aws:lambda:us-east-1:764866452798:layer:libreoffice:7`<br>Link: [`shelfio/libreoffice-lambda-layer`](https://github.com/shelfio/libreoffice-lambda-layer) | all |


### PR DESCRIPTION
Deleted old ARN in attempt to normalize version numbers across regions. Turns out AWS doesn't reset them even on deleting 